### PR TITLE
Restore defvars; refresh after marking a task as done

### DIFF
--- a/beeminder.el
+++ b/beeminder.el
@@ -60,6 +60,7 @@
 (require 'url-http)
 
 (defvar org-state)
+(defvar url-http-end-of-headers)
 
 ;; Configuration
 


### PR DESCRIPTION
You were right about the defvars as a way to remove byte compilation warnings. =) Also, I changed the done hook to refresh the deadline to the next losedate as a way to more easily keep track of closer deadlines.
