### PR TITLE
Add optional `beeminder-skip-deadlines` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ Directly add data to a beeminder goal.
 Fetches all goals for the current user (set via `beeminder-username`) and
 inserts them as a list of org-mode headings.
 
-#### `beeminder-whoami`
+#### `beeminder-refresh-goal`
 
-Fetches the username associated with the current token (set via
-`beeminder-auth-token`).  Not really useful, but good for checking if your
-authorization token is set and valid.
+Fetches goal data for the current headline and updates its properties and
+deadlines.
+
+If the `beeminder-skip-deadlines` property is set to any value (such as "true"),
+the org deadline will not be updated.
 
 #### `beeminder-submit-clocked-time`
 
@@ -98,6 +100,12 @@ Submit all clocked time for the current goal (and any of its sub-tasks).  Only
 time clocked since the `updated-at` property is counted.  Submits the number of
 minutes clocked as the value.  If the goal property `beeminder-unit` is set to
 "hours", it will submit the number of hours worked instead.
+
+#### `beeminder-whoami`
+
+Fetches the username associated with the current token (set via
+`beeminder-auth-token`).  Not really useful, but good for checking if your
+authorization token is set and valid.
 
 
 ### Integrating with org-mode

--- a/beeminder-org.el
+++ b/beeminder-org.el
@@ -78,7 +78,8 @@
       (beeminder--org-update-completion-percentage goal-data)
 
       ;; Update deadline.
-      (beeminder--org-update-deadline goal-data))))
+      (if (beeminder--can-update-deadline-p)
+          (beeminder--org-update-deadline goal-data)))))
 
 ;;;###autoload
 (defun beeminder-my-goals-org ()
@@ -187,6 +188,10 @@ Only call this from within an `org-mode` hook, otherwise
 (defun beeminder--org-beeminder-goal-task-p ()
   "Check if the current org headline is tracked by Beeminder."
   (beeminder--org-beeminder-goal-name))
+
+(defun beeminder--can-update-deadline-p ()
+  "Check if the current org headline supports deadline updating."
+  (not (org-entry-get (point) (beeminder--org-property-name 'skip_deadlines))))
 
 (defun beeminder--org-task-value ()
   "Get value for a beeminder task headline.

--- a/beeminder-settings.el
+++ b/beeminder-settings.el
@@ -44,15 +44,16 @@
   :type '(string))
 
 (defcustom beeminder-properties
-  '((slug .       "beeminder")             ;; Goal identifier.
-    (pledge .     "beeminder-pledge")      ;; Amount of money pledged.
-    (goal_type .  "beeminder-type")        ;; Type of goal.
-    (goalval .    "beeminder-target")      ;; Number the road will eventually reach.
-    (lane .       "beeminder-lane")        ;; Current lane position.
-    (curval .     "beeminder-value")       ;; Last datapoint value.
-    (progress .   "beeminder-progress")    ;; Locally calculated progress.
-    (unit .       "beeminder-unit")        ;; Optional local unit ("hours").
-    (updated_at . "beeminder-updated-at")) ;; Date of last datapoint.
+  '((slug .           "beeminder")                ;; Goal identifier.
+    (pledge .         "beeminder-pledge")         ;; Amount of money pledged.
+    (goal_type .      "beeminder-type")           ;; Type of goal.
+    (goalval .        "beeminder-target")         ;; Number the road will eventually reach.
+    (lane .           "beeminder-lane")           ;; Current lane position.
+    (curval .         "beeminder-value")          ;; Last datapoint value.
+    (progress .       "beeminder-progress")       ;; Locally calculated progress.
+    (unit .           "beeminder-unit")           ;; Optional local unit ("hours").
+    (skip_deadlines . "beeminder-skip-deadlines") ;; If set, will not refresh deadlines.
+    (updated_at .     "beeminder-updated-at"))    ;; Date of last datapoint.
   "Alist mapping property names for Beeminder goals.
 
 The key should be the symbol that the Beeminder API returns, and

--- a/test/beeminder-org-test.el
+++ b/test/beeminder-org-test.el
@@ -133,6 +133,18 @@
       (should-not (string= (org-entry-get (point) "DEADLINE") "2020-01-01 Wed"))
       (should     (string= (org-entry-get (point) "DEADLINE") "2015-04-09 Thu 02:59"))))))
 
+(ert-deftest beeminder-org-test/refresh-goal-skips-deadline-update-if-configured ()
+  (with-org-mode-test
+   "beeminder_task.org"
+   (let ((beeminder-auth-token "ABCDEF")
+         (beeminder-username "example"))
+     (with-mock
+      (mock-get "users/example/goals/example_goal.json" "example_goal.json")
+      (org-entry-put (point) "beeminder-skip-deadlines" "skip")
+      (beeminder-refresh-goal)
+      (should     (string= (org-entry-get (point) "DEADLINE") "2020-01-01 Wed"))
+      (should-not (string= (org-entry-get (point) "DEADLINE") "2015-04-09 Thu 02:59"))))))
+
 (ert-deftest beeminder-org-test/refresh-goal-updates-all-beeminder-properties ()
   (with-org-mode-test
    "beeminder_task.org"


### PR DESCRIPTION
When the property is set to a value, `beeminder-refresh-goal` will not update
the task's deadline.